### PR TITLE
fix(version): don't use freezed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": "8.1"
+    "php": "^8.1"
   },
   "extra": {
     "paas": {


### PR DESCRIPTION
Fixing the deployment issue related to the new php version released on the buildpack